### PR TITLE
Fix return types 

### DIFF
--- a/tic_tac_toe/Board.py
+++ b/tic_tac_toe/Board.py
@@ -90,7 +90,7 @@ class Board:
         else:
             self.state = s.copy()
 
-    def coord_to_pos(self, coord: (int, int)) -> int:
+    def coord_to_pos(self, coord: tuple[int, int]) -> int:
         """
         Converts a 2D board position to a 1D board position.
         Various parts of code prefer one over the other.
@@ -99,7 +99,7 @@ class Board:
         """
         return coord[0] * BOARD_DIM + coord[1]
 
-    def pos_to_coord(self, pos: int) -> (int, int):
+    def pos_to_coord(self, pos: int) -> tuple[int, int]:
         """
         Converts a 1D board position to a 2D board position.
         Various parts of code prefer one over the other.
@@ -142,7 +142,7 @@ class Board:
         """
         return (0 <= pos < BOARD_SIZE) and (self.state[pos] == EMPTY)
 
-    def move(self, position: int, side: int) -> (np.ndarray, GameResult, bool):
+    def move(self, position: int, side: int) -> tuple[np.ndarray, GameResult, bool]:
         """
         Places a piece of side "side" at position "position". The position is to be provided as 1D.
         Throws a ValueError if the position is not EMPTY
@@ -166,7 +166,7 @@ class Board:
 
         return self.state, GameResult.NOT_FINISHED, False
 
-    def apply_dir(self, pos: int, direction: (int, int)) -> int:
+    def apply_dir(self, pos: int, direction: tuple[int, int]) -> int:
         """
         Applies 2D direction dir to 1D position pos.
         Returns the resulting 1D position, or -1 if the resulting position would not be a valid board position.
@@ -186,7 +186,7 @@ class Board:
 
         return row * 3 + col
 
-    def check_win_in_dir(self, pos: int, direction: (int, int)) -> bool:
+    def check_win_in_dir(self, pos: int, direction: tuple[int, int]) -> bool:
         """
         Checks and returns whether there are 3 pieces of the same side in a row if following direction dir
         Used internally to check whether either side has won the game.

--- a/tic_tac_toe/DeepExpDoubleDuelQPlayer.py
+++ b/tic_tac_toe/DeepExpDoubleDuelQPlayer.py
@@ -142,7 +142,7 @@ class ReplayBuffer:
         self.buffer = []
         self.buffer_size = buffer_size
 
-    def add(self, experience: []):
+    def add(self, experience: list):
         """
         Adds a list of experience Tuples to the buffer. If this operation causes the buffer to be longer than its
         defined maximum, old entries will be evicted until the maximum length is achieved. Entries are added and
@@ -153,7 +153,7 @@ class ReplayBuffer:
             self.buffer[0:1] = []
         self.buffer.append(experience)
 
-    def sample(self, size) -> []:
+    def sample(self, size) -> list:
         """
         Returns a random sample of `size` entries from the Replay Buffer. If there are less than `size` entries
         in the buffer, all entries will be returned.
@@ -186,7 +186,7 @@ class DeepExpDoubleDuelQPlayer(Player):
 
         return res
 
-    def create_graph_copy_op(self, src: str, target: str, tau: float) -> [tf.Tensor]:
+    def create_graph_copy_op(self, src: str, target: str, tau: float) -> list[tf.Tensor]:
         """
         Creates and returns a TensorFlow Operation that copies the content of all trainable variables from the
         sub-graph in scope `src` to the sub-graph in scope `target`. Both graphs need to have the same topology and
@@ -289,7 +289,7 @@ class DeepExpDoubleDuelQPlayer(Player):
 
         buffer.add([self.board_position_log[game_length - 1], self.action_log[game_length - 1], None, reward])
 
-    def get_probs(self, input_pos: [np.ndarray], network: QNetwork) -> ([float], [float]):
+    def get_probs(self, input_pos: list[np.ndarray], network: QNetwork) -> tuple[float, float]:
         """
         Feeds the feature vectors `input_pos` (which encode a board states) into the Neural Network and computes the
         Q values and corresponding probabilities for all moves (including illegal ones).
@@ -301,7 +301,7 @@ class DeepExpDoubleDuelQPlayer(Player):
                                                 feed_dict={network.input_positions: input_pos})
         return probs, qvalues
 
-    def get_valid_probs(self, input_pos: [np.ndarray], network: QNetwork, boards: [Board]) -> ([float], [float]):
+    def get_valid_probs(self, input_pos: list[np.ndarray], network: QNetwork, boards: list[Board]) -> tuple[float, float]:
         """
         Evaluates the board positions `input_pos` with the Neural Network `network`. It post-processes the result
         by setting the probability of all illegal moves in the current position to -1.
@@ -327,7 +327,7 @@ class DeepExpDoubleDuelQPlayer(Player):
 
         return probabilities, qvals
 
-    def move(self, board: Board) -> (GameResult, bool):
+    def move(self, board: Board) -> tuple[GameResult, bool]:
         """
         Implements the Player interface and makes a move on Board `board`
         :param board: The Board to make a move on

--- a/tic_tac_toe/DirectPolicyAgent.py
+++ b/tic_tac_toe/DirectPolicyAgent.py
@@ -116,7 +116,7 @@ class ReplayBuffer:
         self.buffer = []
         self.buffer_size = buffer_size
 
-    def add(self, experience: []):
+    def add(self, experience: list):
         """
         Adds a list of experience Tuples to the buffer. If this operation causes the buffer to be longer than its
         defined maximum, old entries will be evicted until the maximum length is achieved. Entries are added and
@@ -127,7 +127,7 @@ class ReplayBuffer:
             self.buffer[0:1] = []
         self.buffer.append(experience)
 
-    def sample(self, size) -> []:
+    def sample(self, size) -> list:
         """
         Returns a random sample of `size` entries from the Replay Buffer. If there are less than `size` entries
         in the buffer, all entries will be returned.
@@ -210,7 +210,7 @@ class DirectPolicyAgent(Player):
         self.board_position_log = []
         self.action_log = []
 
-    def get_probs(self, input_pos: [np.ndarray]) -> ([float], [float]):
+    def get_probs(self, input_pos: list[np.ndarray]) -> tuple[float, float]:
         """
         Compute action probabilities through the Neural Network
         :param input_pos: List of input states for which to compute probabilities
@@ -220,7 +220,7 @@ class DirectPolicyAgent(Player):
                                                feed_dict={self.nn.state_in: input_pos})
         return probs, logits
 
-    def get_valid_probs(self, input_pos: [np.ndarray], boards: [Board]) -> ([float], [float]):
+    def get_valid_probs(self, input_pos: list[np.ndarray], boards: list[Board]) -> tuple[float, float]:
         """
         Evaluates the board positions `input_pos` with the Neural Network `network`. It post-processes the result
         by setting the probability of all illegal moves in the current position to 0.
@@ -244,7 +244,7 @@ class DirectPolicyAgent(Player):
         res = probabilities / probabilities.sum(axis=1, keepdims=True)
         return res
 
-    def move(self, board: Board) -> (GameResult, bool):
+    def move(self, board: Board) -> tuple[GameResult, bool]:
         """
         Makes a move on the given input state
         :param board: The current state of the game
@@ -278,7 +278,7 @@ class DirectPolicyAgent(Player):
 
         return res, finished
 
-    def add_game_to_replay_buffer(self, final_reward: float, rewards: []):
+    def add_game_to_replay_buffer(self, final_reward: float, rewards: list):
         """
         Adds the game history of the current game to the replay buffer. This method is called internally
         after the game has finished
@@ -297,7 +297,7 @@ class DirectPolicyAgent(Player):
         for i in range(game_length):
             buffer.add([self.board_position_log[i], self.action_log[i], rewards[i]])
 
-    def calculate_rewards(self, final_reward: float, length: int) -> [float]:
+    def calculate_rewards(self, final_reward: float, length: int) -> list[float]:
         """
         Computes and returns the discounted rewards for all moves
         :param final_reward: The reward of the final move of the game

--- a/tic_tac_toe/DirectPolicyAgent.py
+++ b/tic_tac_toe/DirectPolicyAgent.py
@@ -210,7 +210,7 @@ class DirectPolicyAgent(Player):
         self.board_position_log = []
         self.action_log = []
 
-    def get_probs(self, input_pos: list[np.ndarray]) -> tuple[float, float]:
+    def get_probs(self, input_pos: list[np.ndarray]) -> tuple[list[float], list[float]]:
         """
         Compute action probabilities through the Neural Network
         :param input_pos: List of input states for which to compute probabilities
@@ -220,7 +220,7 @@ class DirectPolicyAgent(Player):
                                                feed_dict={self.nn.state_in: input_pos})
         return probs, logits
 
-    def get_valid_probs(self, input_pos: list[np.ndarray], boards: list[Board]) -> tuple[float, float]:
+    def get_valid_probs(self, input_pos: list[np.ndarray], boards: list[Board]) -> tuple[list[float], list[float]]:
         """
         Evaluates the board positions `input_pos` with the Neural Network `network`. It post-processes the result
         by setting the probability of all illegal moves in the current position to 0.

--- a/tic_tac_toe/EGreedyNNQPlayer.py
+++ b/tic_tac_toe/EGreedyNNQPlayer.py
@@ -131,7 +131,7 @@ class EGreedyNNQPlayer(Player):
         self.next_max_log = []
         self.values_log = []
 
-    def calculate_targets(self) -> [np.ndarray]:
+    def calculate_targets(self) -> list[np.ndarray]:
         """
         Based on the recorded moves, compute updated estimates of the Q values for the network to learn
         """
@@ -146,7 +146,7 @@ class EGreedyNNQPlayer(Player):
 
         return targets
 
-    def get_probs(self, input_pos: np.ndarray) -> ([float], [float]):
+    def get_probs(self, input_pos: np.ndarray) -> tuple[float, float]:
         """
         Feeds the feature vector `input_pos` which encodes a board state into the Neural Network and computes the
         Q values and corresponding probabilities for all moves (including illegal ones).
@@ -157,7 +157,7 @@ class EGreedyNNQPlayer(Player):
                                                 feed_dict={self.nn.input_positions: [input_pos]})
         return probs[0], qvalues[0]
 
-    def move(self, board: Board) -> (GameResult, bool):
+    def move(self, board: Board) -> tuple[GameResult, bool]:
         """
         Implements the Player interface and makes a move on Board `board`
         :param board: The Board to make a move on

--- a/tic_tac_toe/EGreedyNNQPlayer.py
+++ b/tic_tac_toe/EGreedyNNQPlayer.py
@@ -146,7 +146,7 @@ class EGreedyNNQPlayer(Player):
 
         return targets
 
-    def get_probs(self, input_pos: np.ndarray) -> tuple[float, float]:
+    def get_probs(self, input_pos: np.ndarray) -> tuple[list[float], list[float]]:
         """
         Feeds the feature vector `input_pos` which encodes a board state into the Neural Network and computes the
         Q values and corresponding probabilities for all moves (including illegal ones).

--- a/tic_tac_toe/ExpDoubleDuelQPlayer.py
+++ b/tic_tac_toe/ExpDoubleDuelQPlayer.py
@@ -110,7 +110,7 @@ class ReplayBuffer:
         self.buffer = []
         self.buffer_size = buffer_size
 
-    def add(self, experience: []):
+    def add(self, experience: list):
         """
         Adds a list of experience Tuples to the buffer. If this operation causes the buffer to be longer than its
         defined maximum, old entries will be evicted until the maximum length is achieved. Entries are added and
@@ -121,7 +121,7 @@ class ReplayBuffer:
             self.buffer[0:1] = []
         self.buffer.append(experience)
 
-    def sample(self, size) -> []:
+    def sample(self, size) -> list:
         """
         Returns a random sample of `size` entries from the Replay Buffer. If there are less than `size` entries
         in the buffer, all entries will be returned.
@@ -151,7 +151,7 @@ class ExpDoubleDuelQPlayer(Player):
                         (state == EMPTY).astype(int)])
         return res.reshape(-1)
 
-    def create_graph_copy_op(self, src: str, target: str, tau: float) -> [tf.Tensor]:
+    def create_graph_copy_op(self, src: str, target: str, tau: float) -> list[tf.Tensor]:
         """
         Creates and returns a TensorFlow Operation that copies the content of all trainable variables from the
         sub-graph in scope `src` to the sub-graph in scope `target`. Both graphs need to have the same topology and
@@ -252,7 +252,7 @@ class ExpDoubleDuelQPlayer(Player):
 
         buffer.add([self.board_position_log[game_length - 1], self.action_log[game_length - 1], None, reward])
 
-    def get_probs(self, input_pos: [np.ndarray], network: QNetwork) -> ([float], [float]):
+    def get_probs(self, input_pos: list[np.ndarray], network: QNetwork) -> tuple[float, float]:
         """
         Feeds the feature vectors `input_pos` (which encode a board states) into the Neural Network and computes the
         Q values and corresponding probabilities for all moves (including illegal ones).
@@ -264,7 +264,7 @@ class ExpDoubleDuelQPlayer(Player):
                                                 feed_dict={network.input_positions: input_pos})
         return probs, qvalues
 
-    def get_valid_probs(self, input_pos: [np.ndarray], network: QNetwork, boards: [Board]) -> ([float], [float]):
+    def get_valid_probs(self, input_pos: list[np.ndarray], network: QNetwork, boards: list[Board]) -> tuple[float, float]:
         """
         Evaluates the board positions `input_pos` with the Neural Network `network`. It post-processes the result
         by setting the probability of all illegal moves in the current position to -1.
@@ -290,7 +290,7 @@ class ExpDoubleDuelQPlayer(Player):
 
         return probabilities, qvals
 
-    def move(self, board: Board) -> (GameResult, bool):
+    def move(self, board: Board) -> tuple[GameResult, bool]:
         """
         Implements the Player interface and makes a move on Board `board`
         :param board: The Board to make a move on

--- a/tic_tac_toe/ExpDoubleDuelQPlayer.py
+++ b/tic_tac_toe/ExpDoubleDuelQPlayer.py
@@ -252,7 +252,7 @@ class ExpDoubleDuelQPlayer(Player):
 
         buffer.add([self.board_position_log[game_length - 1], self.action_log[game_length - 1], None, reward])
 
-    def get_probs(self, input_pos: list[np.ndarray], network: QNetwork) -> tuple[float, float]:
+    def get_probs(self, input_pos: list[np.ndarray], network: QNetwork) -> tuple[list[float], list[float]]:
         """
         Feeds the feature vectors `input_pos` (which encode a board states) into the Neural Network and computes the
         Q values and corresponding probabilities for all moves (including illegal ones).
@@ -264,7 +264,7 @@ class ExpDoubleDuelQPlayer(Player):
                                                 feed_dict={network.input_positions: input_pos})
         return probs, qvalues
 
-    def get_valid_probs(self, input_pos: list[np.ndarray], network: QNetwork, boards: list[Board]) -> tuple[float, float]:
+    def get_valid_probs(self, input_pos: list[np.ndarray], network: QNetwork, boards: list[Board]) -> tuple[list[float], list[float]]:
         """
         Evaluates the board positions `input_pos` with the Neural Network `network`. It post-processes the result
         by setting the probability of all illegal moves in the current position to -1.

--- a/tic_tac_toe/MinMaxAgent.py
+++ b/tic_tac_toe/MinMaxAgent.py
@@ -49,7 +49,7 @@ class MinMaxAgent(Player):
         """
         pass
 
-    def _min(self, board: Board) -> (float, int):
+    def _min(self, board: Board) -> tuple[float, int]:
         """
         Evaluate the board position `board` from the Minimizing player's point of view.
 
@@ -100,7 +100,7 @@ class MinMaxAgent(Player):
                 self.cache[board_hash] = (min_value, action)
         return min_value, action
 
-    def _max(self, board: Board) -> (float, int):
+    def _max(self, board: Board) -> tuple[float, int]:
         """
         Evaluate the board position `board` from the Maximizing player's point of view.
 
@@ -151,7 +151,7 @@ class MinMaxAgent(Player):
                 self.cache[board_hash] = (max_value, action)
         return max_value, action
 
-    def move(self, board: Board) -> (GameResult, bool):
+    def move(self, board: Board) -> tuple[GameResult, bool]:
         """
         Making a move according to the MinMax algorithm
 

--- a/tic_tac_toe/MinMaxAgent.py
+++ b/tic_tac_toe/MinMaxAgent.py
@@ -49,7 +49,7 @@ class MinMaxAgent(Player):
         """
         pass
 
-    def _min(self, board: Board) -> (float, int):
+    def _min(self, board: Board) -> tuple[float, int]:
         """
         Evaluate the board position `board` from the Minimizing player's point of view.
 
@@ -100,7 +100,7 @@ class MinMaxAgent(Player):
                 self.cache[board_hash] = (min_value, action)
         return min_value, action
 
-    def _max(self, board: Board) -> (float, int):
+    def _max(self, board: Board) -> tuple[float, int]:
         """
         Evaluate the board position `board` from the Maximizing player's point of view.
 

--- a/tic_tac_toe/Player.py
+++ b/tic_tac_toe/Player.py
@@ -19,7 +19,7 @@ class Player(ABC):
         super().__init__()
 
     @abstractmethod
-    def move(self, board: Board) -> (GameResult, bool):
+    def move(self, board: Board) -> tuple[GameResult, bool]:
         """
         The player should make a move on board `board` and return the result. The return result can usually
         be passed on from the corresponding method in the board class.

--- a/tic_tac_toe/RandomPlayer.py
+++ b/tic_tac_toe/RandomPlayer.py
@@ -19,7 +19,7 @@ class RandomPlayer(Player):
         self.side = None
         super().__init__()
 
-    def move(self, board: Board) -> (GameResult, bool):
+    def move(self, board: Board) -> tuple[GameResult, bool]:
         """
         Making a random move
         :param board: The board to make a move on

--- a/tic_tac_toe/RndMinMaxAgent.py
+++ b/tic_tac_toe/RndMinMaxAgent.py
@@ -52,7 +52,7 @@ class RndMinMaxAgent(Player):
         """
         pass
 
-    def _min(self, board: Board) -> int:
+    def _min(self, board: Board) -> tuple[float, int]:
         """
         Evaluate the board position `board` from the Minimizing player's point of view.
 
@@ -103,7 +103,7 @@ class RndMinMaxAgent(Player):
 
         return random.choice(best_moves)
 
-    def _max(self, board: Board) -> int:
+    def _max(self, board: Board) -> tuple[float, int]:
         """
         Evaluate the board position `board` from the Maximizing player's point of view.
 
@@ -153,7 +153,7 @@ class RndMinMaxAgent(Player):
 
         return random.choice(best_moves)
 
-    def move(self, board: Board) -> (GameResult, bool):
+    def move(self, board: Board) -> tuple[GameResult, bool]:
         """
 
         Making a move according to the MinMax algorithm. If more than one best move exist, chooses amongst them

--- a/tic_tac_toe/RndMinMaxAgent.py
+++ b/tic_tac_toe/RndMinMaxAgent.py
@@ -52,7 +52,7 @@ class RndMinMaxAgent(Player):
         """
         pass
 
-    def _min(self, board: Board) -> int:
+    def _min(self, board: Board) -> tuple[float, int]:
         """
         Evaluate the board position `board` from the Minimizing player's point of view.
 
@@ -103,7 +103,7 @@ class RndMinMaxAgent(Player):
 
         return random.choice(best_moves)
 
-    def _max(self, board: Board) -> int:
+    def _max(self, board: Board) -> tuple[float, int]:
         """
         Evaluate the board position `board` from the Maximizing player's point of view.
 

--- a/tic_tac_toe/SimpleNNQPlayer.py
+++ b/tic_tac_toe/SimpleNNQPlayer.py
@@ -128,7 +128,7 @@ class NNQPlayer(Player):
         self.next_max_log = []
         self.values_log = []
 
-    def calculate_targets(self) -> [np.ndarray]:
+    def calculate_targets(self) -> list[np.ndarray]:
         """
         Based on the recorded moves, compute updated estimates of the Q values for the network to learn
         """
@@ -143,7 +143,7 @@ class NNQPlayer(Player):
 
         return targets
 
-    def get_probs(self, input_pos: np.ndarray) -> ([float], [float]):
+    def get_probs(self, input_pos: np.ndarray) -> tuple[list[float], list[float]]:
         """
         Feeds the feature vector `input_pos` which encodes a board state into the Neural Network and computes the
         Q values and corresponding probabilities for all moves (including illegal ones).
@@ -154,7 +154,7 @@ class NNQPlayer(Player):
                                                 feed_dict={self.nn.input_positions: [input_pos]})
         return probs[0], qvalues[0]
 
-    def move(self, board: Board) -> (GameResult, bool):
+    def move(self, board: Board) -> tuple[GameResult, bool]:
         """
         Implements the Player interface and makes a move on Board `board`
         :param board: The Board to make a move on


### PR DESCRIPTION
1. Fix error such as "Tuple expression not allowed in type annotation Use tuple[T1, ..., Tn] to indicate a tuple type or Union[T1, T2] to indicate a union typePylancereportInvalidTypeForm"

2. Fix return type of _min and _max on RndMinMaxAgent, both of which return a tuple